### PR TITLE
Remove pose from heightmaps, add gui argument

### DIFF
--- a/launch/kingfisher_gazebo_worlds.launch
+++ b/launch/kingfisher_gazebo_worlds.launch
@@ -7,6 +7,7 @@
        value="$(find kingfisher_gazebo)/config/custom_rosconsole.conf"/>
 
   <!-- Command line arguments -->
+  <arg name="gui" default="true" />
   <arg name="name" default="kingfisher" />
   <arg name="imu" default="true" />
   <arg name="gps" default="true" />
@@ -25,6 +26,7 @@
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <!--<arg name="world_name" value="$(find kingfisher_gazebo)/worlds/lake_buoy.world"/>-->
     <arg name="world_name" value="$(find kingfisher_gazebo)/worlds/$(arg world)"/>
+    <arg name="gui" value="$(arg gui)"/>
     <arg name="verbose" value="true"/>
   </include>
   

--- a/worlds/lake.world
+++ b/worlds/lake.world
@@ -74,9 +74,9 @@
     
     <!-- The models below should be included in kingfisher_gazebo package -->
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitutde/height fo the lake!-->
-      <pose> 0 0 5 0 0 0 </pose>
+      <!-- Note - the pose tag doesn't work for heightmaps, so you need
+      to go into the model file to change the altitutde/height fo the lake!
+      See the Gazebo issue: https://bitbucket.org/osrf/gazebo/issues/2167-->
       <uri>model://models/lake</uri>
     </include>
 

--- a/worlds/lake_buoy.world
+++ b/worlds/lake_buoy.world
@@ -74,9 +74,9 @@
 
     <!-- The models below should be included in kingfisher_gazebo package -->
     <include>
-      <!-- Note - the pose tag doesn't seem to work for heightmaps, so you need
-      to go into the model file to change the altitutde/height fo the lake!-->
-      <pose> 0 0 5 0 0 0 </pose>
+      <!-- Note - the pose tag doesn't work for heightmaps, so you need
+      to go into the model file to change the altitutde/height fo the lake!
+      See the Gazebo issue: https://bitbucket.org/osrf/gazebo/issues/2167-->
       <uri>model://models/lake</uri>
     </include>
 


### PR DESCRIPTION
Gazebo doesn't interpret heightmap poses, but other SDF consumers might (such as GzWeb), so to keep things consistent, I propose removing it.

Also exposed the `gui` param so that `kingfisher_gazebo_worlds.launch` can be run headless.